### PR TITLE
Implement fallback unknown sign image

### DIFF
--- a/sign.php
+++ b/sign.php
@@ -18,8 +18,7 @@ foreach ($signs as $id) {
     $id = basename($id); // prevent directory traversal
     $file = __DIR__ . '/signs/' . $id . '.png';
     if (!is_file($file)) {
-        // skip missing files
-        continue;
+        $file = __DIR__ . '/signs/unknown.png';
     }
     $img = @imagecreatefrompng($file);
     if ($img === false) {


### PR DESCRIPTION
## Summary
- use a default `unknown.png` whenever a requested sign image is missing

## Testing
- `php -S 127.0.0.1:8000` (manual server test)
- `curl -I 'http://127.0.0.1:8000/sign.php?ids=101'`
- `curl -I 'http://127.0.0.1:8000/sign.php?ids=invalidid'`


------
https://chatgpt.com/codex/tasks/task_e_688a37493f088320b17a4067703ed9fe